### PR TITLE
Fix bug assign nil to null type in union type

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -595,7 +595,7 @@ func (st symtab) makeRecordCodec(enclosingNamespace string, schema interface{}) 
 			for idx, field := range someRecord.Fields {
 				var value interface{}
 				// check whether field datum is valid
-				if reflect.ValueOf(field.Datum).IsValid() {
+				if reflect.ValueOf(field.Datum).IsValid() || field.Datum == nil {
 					value = field.Datum
 				} else if field.hasDefault {
 					value = field.defval


### PR DESCRIPTION
My problem:
Cannot assign nil or just left it to be nil to a null type in union type with schema like this:
{
name'type': 'record',
'name': 'Msg',
'fields' : [
{'name': 'value', 'type': ['string', 'null']}
]}
It will say "no data and default value"
Because line 598 of codec.go
field.Datum = nil
reflect.ValueOf(field.Datum).IsValid() == false